### PR TITLE
Returns self in setter to add extra syntax sugar candy / chain calls

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -45,10 +45,11 @@
      *
      * @param messages {object} The messages source.
      *
-     * @return void
+     * @return {Object} reference to self
      */
     Lang.prototype.setMessages = function (messages) {
         this.messages = messages;
+        return this;
     };
 
     /**
@@ -65,10 +66,11 @@
      *
      * @param locale {string} The locale to set.
      *
-     * @return void
+     * @return {Object} reference to self
      */
     Lang.prototype.setLocale = function (locale) {
         this.locale = locale;
+        return this;
     };
 
     /**
@@ -85,10 +87,11 @@
      *
      * @param string fallback
      *
-     * @return void
+     * @return {Object} reference to self
      */
     Lang.prototype.setFallback = function (fallback) {
         this.fallback = fallback;
+        return this;
     };
 
     /**


### PR DESCRIPTION
Sometimes I like returning "this" in the setters since it helps chaining calls. For example in the tests I could do:
```javascript
var enMessage = lang.setLocale('es').setFallback('en').get('fallback.test');
```
Instead of
```javascript
lang.setLocale('en');
lang.setFallback('en');
var enMessage = lang.get('fallback.test');
```
A matter of preference :) No hard feelings if this added "syntax sugar candy" is disliked