### PR TITLE
Adjust count check

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -200,10 +200,10 @@
         }
 
         // Standard rules
-        if (count > 1) {
-            return messageParts[1];
-        } else {
+        if (count === 1) {
             return messageParts[0];
+        } else {
+            return messageParts[1];
         }
     };
 


### PR DESCRIPTION
Currently if you have a `count` of `0`, it returns the singular version.
eg. `0 entry`, where it should be `0 entries`.

Now only a count of `1` gets the singular version.