### PR TITLE
adds the locale param to the choice and get methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,17 @@ var lang = new Lang({
     messages: {
         'en.greetings': {
             'hi': 'Hi'
+        },
+        'es.greetings': {
+            'hi': 'Hola'
         }
     }
 });
 
 lang.has('greetings.hi');
+// > true
+
+lang.has('greetings.hi', 'es');
 // > true
 
 lang.has('greetings.hello');
@@ -164,12 +170,18 @@ var lang = new Lang({
     messages: {
         'en.greetings': {
             'hi': 'Hi'
+        },
+        'es.greetings': {
+            'hi': 'Hola'
         }
     }
 });
 
 lang.get('greetings.hi');
 // > "Hi"
+
+lang.get('greetings.hi', {}, 'es');
+// > "Hola"
 
 lang.get('greetings.hello');
 // > "greetings.hello"
@@ -188,15 +200,21 @@ var lang = new Lang({
     messages: {
         'en.fruits': {
             'apple': 'apple|apples'
+        },
+        'es.greetings': {
+            'apple': 'manzana|manzanas'
         }
     }
 });
 
-lang.get('fruits.apple', 1);
+lang.choice('fruits.apple', 1);
 // > "apple"
 
-lang.get('fruits.apple', 4);
+lang.choice('fruits.apple', 4);
 // > "apples"
+
+lang.choice('fruits.apple', 4, {}, 'es');
+// > "manzanas"
 ```
 
 #### `transChoice`

--- a/src/lang.js
+++ b/src/lang.js
@@ -103,7 +103,7 @@
         if (typeof key !== 'string' || !this.messages) {
             return false;
         }
-        locale = locale || this.getLocale();
+        
         return this._getMessage(key, locale) !== null;
     }
 
@@ -112,15 +112,16 @@
      *
      * @param key {string} The key of the message.
      * @param replacements {object} The replacements to be done in the message.
+     * @param locale {string} The locale to use, if not passed use the default locale.
      *
      * @return {string} The translation message, if not found the given key.
      */
-    Lang.prototype.get = function (key, replacements) {
+    Lang.prototype.get = function (key, replacements, locale) {
         if (!this.has(key)) {
             return key;
         }
 
-        var message = this._getMessage(key);
+        var message = this._getMessage(key, locale);
         if (message === null) {
             return key;
         }
@@ -146,23 +147,24 @@
     };
 
     /**
-     * Get the plural or singular form of the message specified based on an integer value.
+     * Gets the plural or singular form of the message specified based on an integer value.
      *
      * @param key {string} The key of the message.
-     * @param count {integer} The number of elements.
+     * @param number {integer} The number of elements.
      * @param replacements {object} The replacements to be done in the message.
+     * @param locale {string} The locale to use, if not passed use the default locale.
      *
      * @return {string} The translation message according to an integer value.
      */
-    Lang.prototype.choice = function (key, count, replacements) {
+    Lang.prototype.choice = function (key, number, replacements, locale) {
         // Set default values for parameters replace and locale
         replacements = typeof replacements !== 'undefined' ? replacements : {};
 
         // The count must be replaced if found in the message
-        replacements.count = count;
+        replacements.count = number;
 
         // Message to get the plural or singular
-        var message = this.get(key, replacements);
+        var message = this.get(key, replacements, locale);
 
         // Check if message is not null or undefined
         if (message === null || message === undefined) {
@@ -194,13 +196,13 @@
 
         // Check the explicit rules
         for (var j = 0; j < explicitRules.length; j++) {
-            if (this._testInterval(count, explicitRules[j])) {
+            if (this._testInterval(number, explicitRules[j])) {
                 return messageParts[j];
             }
         }
 
         // Standard rules
-        if (count === 1) {
+        if (number === 1) {
             return messageParts[0];
         } else {
             return messageParts[1];

--- a/test/spec/lang_choice_spec.js
+++ b/test/spec/lang_choice_spec.js
@@ -13,7 +13,6 @@ describe('The lang.choice() method', function () {
         });
     });
 
-
     it('should exists', function () {
         expect(lang.choice).toBeDefined();
     });
@@ -37,6 +36,11 @@ describe('The lang.choice() method', function () {
         expect(lang.choice('validation.accepted', 1, {
             'attribute': 'foo'
         })).toBe('The foo must be accepted.');
+    });
+
+    it('should return the expected message with changed locale', function() {
+        expect(lang.choice('messages.home', 1)).toBe('Home');
+        expect(lang.choice('messages.home', 1, {}, 'es')).toBe('Inicio');
     });
 
 });

--- a/test/spec/lang_get_spec.js
+++ b/test/spec/lang_get_spec.js
@@ -47,4 +47,8 @@ describe('The lang.get() method', function () {
         })).toBe('The foo must be accepted.');
     });
 
+    it('should return the expected message with changed locale', function() {
+        expect(lang.get('messages.home')).toBe('Home');
+        expect(lang.get('messages.home', {}, 'es')).toBe('Inicio');
+    });
 });


### PR DESCRIPTION
also:

- renames the parameter `count` for `number`
- adds tests for the `locale` param in both `Lang.choice()` and `Lang.get()` methods
- removes an unnecessary check for `locale` on the `Lang.has()` method, that check is done already inside of the `Lang._getMessage()` method
- updates the Readme with the locale documentation for `Lang.has()`, `Lang.get()` and `Lang.choice()` methods
- fixes the `Lang.choice()` documentation in the Readme as it was using the `get()` instead of `choice()` method

solves issues #5 and #6 