### PR TITLE
Added plural form for all the locales available in Laravel

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -201,12 +201,9 @@
             }
         }
 
-        // Standard rules
-        if (number === 1) {
-            return messageParts[0];
-        } else {
-            return messageParts[1];
-        }
+        var pluralForm = this._getPluralForm(number);
+
+        return messageParts[pluralForm];
     };
 
 
@@ -309,6 +306,149 @@
          */
 
         return false;
+    };
+
+    /**
+     * Returns the plural position to use for the given locale and number.
+     *
+     * The plural rules are derived from code of the Zend Framework (2010-09-25),
+     * which is subject to the new BSD license (http://framework.zend.com/license/new-bsd).
+     * Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+     *
+     * @param {Number} count
+     * @return {Number}
+     */
+    Lang.prototype._getPluralForm = function (count) {
+        switch (this.locale) {
+            case 'az':
+            case 'bo':
+            case 'dz':
+            case 'id':
+            case 'ja':
+            case 'jv':
+            case 'ka':
+            case 'km':
+            case 'kn':
+            case 'ko':
+            case 'ms':
+            case 'th':
+            case 'tr':
+            case 'vi':
+            case 'zh':
+                return 0;
+
+            case 'af':
+            case 'bn':
+            case 'bg':
+            case 'ca':
+            case 'da':
+            case 'de':
+            case 'el':
+            case 'en':
+            case 'eo':
+            case 'es':
+            case 'et':
+            case 'eu':
+            case 'fa':
+            case 'fi':
+            case 'fo':
+            case 'fur':
+            case 'fy':
+            case 'gl':
+            case 'gu':
+            case 'ha':
+            case 'he':
+            case 'hu':
+            case 'is':
+            case 'it':
+            case 'ku':
+            case 'lb':
+            case 'ml':
+            case 'mn':
+            case 'mr':
+            case 'nah':
+            case 'nb':
+            case 'ne':
+            case 'nl':
+            case 'nn':
+            case 'no':
+            case 'om':
+            case 'or':
+            case 'pa':
+            case 'pap':
+            case 'ps':
+            case 'pt':
+            case 'so':
+            case 'sq':
+            case 'sv':
+            case 'sw':
+            case 'ta':
+            case 'te':
+            case 'tk':
+            case 'ur':
+            case 'zu':
+                return (count == 1) ? 0 : 1;
+
+            case 'am':
+            case 'bh':
+            case 'fil':
+            case 'fr':
+            case 'gun':
+            case 'hi':
+            case 'hy':
+            case 'ln':
+            case 'mg':
+            case 'nso':
+            case 'xbr':
+            case 'ti':
+            case 'wa':
+                return ((count == 0) || (count == 1)) ? 0 : 1;
+
+            case 'be':
+            case 'bs':
+            case 'hr':
+            case 'ru':
+            case 'sr':
+            case 'uk':
+                return ((count % 10 == 1) && (count % 100 != 11)) ? 0 : (((count % 10 >= 2) && (count % 10 <= 4) && ((count % 100 < 10) || (count % 100 >= 20))) ? 1 : 2);
+
+            case 'cs':
+            case 'sk':
+                return (count == 1) ? 0 : (((count >= 2) && (count <= 4)) ? 1 : 2);
+
+            case 'ga':
+                return (count == 1) ? 0 : ((count == 2) ? 1 : 2);
+
+            case 'lt':
+                return ((count % 10 == 1) && (count % 100 != 11)) ? 0 : (((count % 10 >= 2) && ((count % 100 < 10) || (count % 100 >= 20))) ? 1 : 2);
+
+            case 'sl':
+                return (count % 100 == 1) ? 0 : ((count % 100 == 2) ? 1 : (((count % 100 == 3) || (count % 100 == 4)) ? 2 : 3));
+
+            case 'mk':
+                return (count % 10 == 1) ? 0 : 1;
+
+            case 'mt':
+                return (count == 1) ? 0 : (((count == 0) || ((count % 100 > 1) && (count % 100 < 11))) ? 1 : (((count % 100 > 10) && (count % 100 < 20)) ? 2 : 3));
+
+            case 'lv':
+                return (count == 0) ? 0 : (((count % 10 == 1) && (count % 100 != 11)) ? 1 : 2);
+
+            case 'pl':
+                return (count == 1) ? 0 : (((count % 10 >= 2) && (count % 10 <= 4) && ((count % 100 < 12) || (count % 100 > 14))) ? 1 : 2);
+
+            case 'cy':
+                return (count == 1) ? 0 : ((count == 2) ? 1 : (((count == 8) || (count == 11)) ? 2 : 3));
+
+            case 'ro':
+                return (count == 1) ? 0 : (((count == 0) || ((count % 100 > 0) && (count % 100 < 20))) ? 1 : 2);
+
+            case 'ar':
+                return (count == 0) ? 0 : ((count == 1) ? 1 : ((count == 2) ? 2 : (((count % 100 >= 3) && (count % 100 <= 10)) ? 3 : (((count % 100 >= 11) && (count % 100 <= 99)) ? 4 : 5))));
+
+            default:
+                return 0;
+        }
     };
 
     return Lang;

--- a/test/fixture/messages.json
+++ b/test/fixture/messages.json
@@ -111,6 +111,9 @@
         "previous": "&laquo; Previous",
         "next": "Next &raquo;"
     },
+    "en.plural": {
+        "year": ":count year|:count years"
+    },
     "en.reminders": {
         "password": "Passwords must be at least six characters and match the confirmation.",
         "user": "We can't find a user with that e-mail address.",
@@ -189,5 +192,8 @@
         "save": "Guardar",
         "language": "Idioma",
         "settingsSaved": "Configuraci\u00f3n guardada satisfactoriamente!"
+    },
+    "ru.plural": {
+        "year": ":count год|:count года|:count лет"
     }
 }

--- a/test/spec/lang_choice_spec.js
+++ b/test/spec/lang_choice_spec.js
@@ -31,6 +31,18 @@ describe('The lang.choice() method', function () {
         expect(lang.choice('messages.plural', 10)).toBe('a million apples');
     });
 
+    it('should return the expected message', function () {
+        lang.setLocale('en');
+        expect(lang.choice('plural.year', 1)).toBe('1 year');
+        expect(lang.choice('plural.year', 2)).toBe('2 years');
+        expect(lang.choice('plural.year', 5)).toBe('5 years');
+
+        lang.setLocale('ru');
+        expect(lang.choice('plural.year', 1)).toBe('1 год');
+        expect(lang.choice('plural.year', 2)).toBe('2 года');
+        expect(lang.choice('plural.year', 5)).toBe('5 лет');
+    });
+
     it('should return the expected message with replacements', function () {
         expect(lang.choice('validation.accepted', 1)).toBe('The :attribute must be accepted.');
         expect(lang.choice('validation.accepted', 1, {


### PR DESCRIPTION
My piece of work for this issue: #6 

Isolated tests and new group of messages added for this use case.

*// I've wrote Zend Framework copyrights because it's converted part of PHP code from Laravel translator and it has Zend copyrights too. Not sure if there should be the copyrights in this case.*