### PR TITLE
Laravel support added and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # Lang.js – v1.0.0
 
 [![Build Status](https://travis-ci.org/rmariuzzo/Lang.js.svg)](https://travis-ci.org/rmariuzzo/Lang.js)
+![Laravel 5.0](https://img.shields.io/badge/Laravel-5.0-f4645f.svg)
 ![Laravel 5.1](https://img.shields.io/badge/Laravel-5.1-f4645f.svg)
+![Laravel 5.2](https://img.shields.io/badge/Laravel-5.2-f4645f.svg)
+![Laravel 5.3](https://img.shields.io/badge/Laravel-5.3-f4645f.svg)
 ![NPM Montly Downloads](https://img.shields.io/npm/dm/lang.js.svg)
-[![Join the chat at https://gitter.im/rmariuzzo/Lang.js](https://img.shields.io/badge/Gitter-Join%20chat-45cba1.svg)](https://gitter.im/rmariuzzo/Lang.js)
 ![NPM package](https://img.shields.io/badge/NPM-%E2%9C%93-cb3837.svg)
 ![Bower package](https://img.shields.io/badge/bower-%E2%9C%93-FFCC2F.svg)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/rmariuzzo/Lang.js/master/LICENSE)
 
 Localization library written in JavaScript highly inspired on Laravel's Lang.
 
-**Notice**: This repository host the JavaScript library used for [Laravel JS Localization](https://github.com/rmariuzzo/Laravel-JS-Localization). If you are already using Laravel JS Localization you don't need to use this too as it come automatically bundled.
+ > 💁 **Heads up!** This repository host the JavaScript library used for [Laravel JS Localization](https://github.com/rmariuzzo/Laravel-JS-Localization). If you are already using Laravel JS Localization you don't need to use this too as it come automatically bundled.
 
 ## Installation
 


### PR DESCRIPTION
I'm updating the README to include how the library matches all Laravel 5 Translator methods.

In the other hand, I removed the badge concerning NPM downloads because I consider it useless, since this library isn't aimed to be used in standalone (but I still hope developer can integrate it somewhere else).