### PR TITLE
Removed exception on throw

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -349,7 +349,7 @@
 
         var matches = interval.match(intervalRegexp);
         if (!matches) {
-            throw new 'Invalid interval: ' + interval;
+            throw 'Invalid interval: ' + interval;
         }
 
         if (matches[2]) {


### PR DESCRIPTION
Removed a new over an initializer that gave exception when throwing this error because throw was trying to "throw" a non-oject.