### PR TITLE
ReferenceError: options is not defined

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -77,7 +77,7 @@
      * @return {string} The current locale.
      */
     Lang.prototype.getLocale = function() {
-        return this.locale || options.fallback;
+        return this.locale || this.fallback;
     };
 
     /**


### PR DESCRIPTION
When no locale is set, trying to access fallback from options variable gives a ReferenceError in getLocale(). fallback is set in the constructor.