### PR TITLE
Should not throw an error if message's root key doesn't exist

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -281,7 +281,7 @@
         // Get message from default locale.
         var message = this.messages[key.source];
         var entries = key.entries.slice();
-        while (entries.length && (message = message[entries.shift()]))
+        while (entries.length && message !== undefined && (message = message[entries.shift()]))
         ;
 
         // Get message from fallback locale.

--- a/test/spec/lang_fallback_spec.js
+++ b/test/spec/lang_fallback_spec.js
@@ -42,4 +42,20 @@ describe('The lang\'s fallback locale feature', function() {
         expect(lang.get('greetings.hello')).toBe(messages['en.greetings'].hello);
     });
 
+    it('should not throw an error when the message is not defined and a fallback is set', function() {
+        var messages = {
+            'en.greetings': {
+                'hi': 'Hi',
+                'hello': 'Hello'
+            }
+        };
+        lang = new Lang({
+            messages: messages
+        });
+        lang.setLocale('it');
+        lang.setFallback('en');
+        expect(function() {
+            lang.get('greetings.hello');
+        }).not.toThrow();
+    });
 });


### PR DESCRIPTION
There is a specific case where an exception gets thrown if:
- a fallback language is set.
- the message being retrieved doesn't have the root? key defined.

Something like
```
var messages = {
  'en.foo': {
    bar: 'bar'
  };
};

var lang = new Lang({
  messages: messages
});
lang.setLocale('it');
lang.setFallback('en');
lang.get('foo.bar');
```

will throw an error in `_getMessage` because `it.foo` is undefined.
It doesn't throw if there is at least one translation defined under `it.foo`, nor if a fallback isn't set.