### PR TITLE
Fixes #54. Add support for any depth dotted keys

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -293,18 +293,24 @@
         return message;
     };
 
-    Lang.prototype._findMessageInTree = function(entries, message) {
-        while (entries.length && message !== undefined) {
-            var dottedKey = entries.join('.');
-            if (message[dottedKey]) {
-                message = message[dottedKey];
+    /**
+     * Find a message in a translation tree using both dotted keys and regular ones
+     *
+     * @param pathSegments {array} An array of path segments such as ['family', 'father']
+     * @param tree {object} The translation tree
+     */
+    Lang.prototype._findMessageInTree = function(pathSegments, tree) {
+        while (pathSegments.length && tree !== undefined) {
+            var dottedKey = pathSegments.join('.');
+            if (tree[dottedKey]) {
+                tree = tree[dottedKey];
                 break;
             }
 
-            message = message[entries.shift()]
+            tree = tree[pathSegments.shift()]
         }
 
-        return message;
+        return tree;
     };
 
     /**
@@ -319,13 +325,13 @@
         for (var replace in replacements) {
             message = message.replace(new RegExp(':' + replace, 'gi'), function(match) {
                 var value = replacements[replace];
-                
+
                 // Capitalize all characters.
                 var allCaps = match === match.toUpperCase();
                 if (allCaps) {
                     return value.toUpperCase();
                 }
-                
+
                 // Capitalize first letter.
                 var firstCap = match === match.replace(/\w/i, function(letter) {
                     return letter.toUpperCase();
@@ -333,7 +339,7 @@
                 if (firstCap) {
                     return value.charAt(0).toUpperCase() + value.slice(1);
                 }
-                
+
                 return value;
             })
         }

--- a/src/lang.js
+++ b/src/lang.js
@@ -279,21 +279,29 @@
         }
 
         // Get message from default locale.
-        var message = this.messages[key.source];
-        var entries = key.entries.slice();
-        while (entries.length && message !== undefined && (message = message[entries.shift()]))
-        ;
+        var message = this._findMessageInTree(key.entries.slice(), this.messages[key.source]);
 
         // Get message from fallback locale.
         if (typeof message !== 'string' && this.messages[key.sourceFallback]) {
-            message = this.messages[key.sourceFallback];
-            entries = key.entries.slice();
-            while (entries.length && (message = message[entries.shift()]))
-            ;
+            message = this._findMessageInTree(key.entries.slice(), this.messages[key.sourceFallback]);
         }
 
         if (typeof message !== 'string') {
             return null;
+        }
+
+        return message;
+    };
+
+    Lang.prototype._findMessageInTree = function(entries, message) {
+        while (entries.length && message !== undefined) {
+            var dottedKey = entries.join('.');
+            if (message[dottedKey]) {
+                message = message[dottedKey];
+                break;
+            }
+
+            message = message[entries.shift()]
         }
 
         return message;

--- a/test/fixture/messages.json
+++ b/test/fixture/messages.json
@@ -108,7 +108,10 @@
             }
         },
         "plural": "one apple|a million apples",
-        "dot.in.key": "Dot In Key"
+        "dot.in.key": "Dot In Key",
+        "category": {
+            "dot.in.key": "Dot In Key"
+        }
     },
     "en.pagination": {
         "previous": "&laquo; Previous",

--- a/test/spec/lang_get_spec.js
+++ b/test/spec/lang_get_spec.js
@@ -68,4 +68,8 @@ describe('The lang.get() method', function () {
     it('should return the expected message if the key has a dot', function() {
         expect(lang.get('messages.dot.in.key')).toBe('Dot In Key');
     })
+
+    it('should return the expected message if the key is nested and has a dot', function() {
+        expect(lang.get('messages.category.dot.in.key')).toBe('Dot In Key');
+    })
 });


### PR DESCRIPTION
Add support for dotted keys at any level of the message tree (fix #54)

```
"en.messages": {
        "dot.in.key": "Dot In Key",
        "category": {
                "dot.in.key": "Dot In Key 2"
        }
}

lang.getMessage('messages.dot.in.key') // Returns 'Dot In Key'
lang.getMessage('messages.category.dot.in.key') // Returns 'Dot In Key 2'
```