### PR TITLE
Fixes replacements when different keys contains same prefix

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -332,6 +332,18 @@
     };
 
     /**
+     * Sort replacement keys by length in descending order.
+     *
+     * @param a {string} Replacement key
+     * @param b {string} Sibling replacement key
+     * @return {number}
+     * @private
+     */
+    Lang.prototype._sortReplacementKeys = function(a, b) {
+        return b.length - a.length;
+    };
+
+    /**
      * Apply replacements to a string message containing placeholders.
      *
      * @param message {string} The text message.
@@ -340,8 +352,10 @@
      * @return {string} The string message with replacements applied.
      */
     Lang.prototype._applyReplacements = function(message, replacements) {
-        for (var replace in replacements) {
-            message = message.replace(new RegExp(':' + replace, 'gi'), function(match) {
+        var keys = Object.keys(replacements).sort(this._sortReplacementKeys);
+
+        keys.forEach(function(replace) {
+            message = message.replace(new RegExp(':' + replace, 'gi'), function (match) {
                 var value = replacements[replace];
 
                 // Capitalize all characters.
@@ -360,7 +374,7 @@
 
                 return value;
             })
-        }
+        });
         return message;
     };
 

--- a/test/fixture/messages.json
+++ b/test/fixture/messages.json
@@ -211,5 +211,8 @@
     },
     "ru.plural": {
         "year": ":count год|:count года|:count лет"
+    },
+    "en.unique": {
+        "samePrefixKeys": "Your order contains :items items with :itemsPapayas papayas and :itemsMangoes mangoes"
     }
 }

--- a/test/spec/lang_get_spec.js
+++ b/test/spec/lang_get_spec.js
@@ -76,5 +76,13 @@ describe('The lang.get() method', function () {
 
     it('should return an empty string', function() {
         expect(lang.get('messages.empty')).toBe('');
-    })
+    });
+
+    it('should return the expected message when keys has equal prefix', function() {
+        expect(lang.get('unique.samePrefixKeys', {
+            items: 5,
+            itemsPapayas: 3,
+            itemsMangoes: 2
+        })).toBe('Your order contains 5 items with 3 papayas and 2 mangoes');
+    });
 });

--- a/test/spec/lang_trans_spec.js
+++ b/test/spec/lang_trans_spec.js
@@ -54,5 +54,4 @@ describe('The lang.trans() method', function () {
             'attribute': 'foo'
         })).toBe('The foo must be accepted.');
     });
-
 });


### PR DESCRIPTION
When message contains replacement keys that start with the same string as one of the keys, replacement is not working correctly.

Here's unit test demonstrating the issue:
```json
    …
    "en.unique": {
        "samePrefixKeys": "Your order contains :items items with :itemsPapayas papayas and :itemsMangoes mangoes"
    }
```

```js
describe('The lang.get() method', function () {
    …
    it('should return the expected message when keys has equal prefix', function() {
        expect(lang.get('unique.samePrefixKeys', {
            items: 5,
            itemsPapayas: 3,
            itemsMangoes: 2
        })).toBe('Your order contains 5 items with 3 papayas and 2 mangoes');
    });
```

```bash
> jasmine-node test/spec/

.........................F..........................

Failures:

  1) The lang.get() method should return the expected message when keys has equal prefix
   Message:
     Expected 'Your order contains 5 items with 5Papayas papayas and 5Mangoes mangoes' 
        to be 'Your order contains 5 items with 3 papayas and 2 mangoes'.

52 tests, 97 assertions, 1 failure, 0 skipped
```

This PR fixes just this&zwnj;_!_