### PR TITLE
Default Plural Form Support

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -222,8 +222,12 @@
         }
 
         var pluralForm = this._getPluralForm(number);
+        //Check if pluralForm exists
+        if (messageParts.length > pluralForm) {
+            return messageParts[pluralForm];
+        }
 
-        return messageParts[pluralForm];
+        return messageParts[0];
     };
 
     /**
@@ -645,7 +649,10 @@
                                     : 5))));
 
             default:
-                return 0;
+                //By default supports two plural forms
+                return (count == 1)
+                    ? 0
+                    : 1;
         }
     };
 


### PR DESCRIPTION
@rmariuzzo Please consider this change

Adds a default plural form support for use with locales not listed in getPluralForm function.