### PR TITLE
Priorize the full key translation

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -282,12 +282,18 @@
         // Get message from default locale.
         var message = this.messages[key.source];
         var entries = key.entries.slice();
-        var subKey = '';
-        while (entries.length && message !== undefined) {
-            var subKey = !subKey ? entries.shift() : subKey.concat('.', entries.shift());
-            if (message[subKey] !== undefined) {
-                message = message[subKey]
-                subKey = '';
+        var subKey = entries.join('.');
+
+        // Priorize the full key translation
+        if (message[subKey] !== undefined) {
+            message = message[subKey]
+        } else {
+            while (entries.length && message !== undefined) {
+                var subKey = !subKey ? entries.shift() : subKey.concat('.', entries.shift());
+                if (message[subKey] !== undefined) {
+                    message = message[subKey]
+                    subKey = '';
+                }
             }
         }
 
@@ -295,12 +301,18 @@
         if (typeof message !== 'string' && this.messages[key.sourceFallback]) {
             message = this.messages[key.sourceFallback];
             entries = key.entries.slice();
-            subKey = '';
-            while (entries.length && message !== undefined) {
-                var subKey = !subKey ? entries.shift() : subKey.concat('.', entries.shift());
-                if (message[subKey]) {
-                    message = message[subKey]
-                    subKey = '';
+            subKey = entries.join('.');
+
+            // Priorize the full key translation
+            if (message[subKey] !== undefined) {
+                message = message[subKey]
+            } else {
+                while (entries.length && message !== undefined) {
+                    var subKey = !subKey ? entries.shift() : subKey.concat('.', entries.shift());
+                    if (message[subKey]) {
+                        message = message[subKey]
+                        subKey = '';
+                    }
                 }
             }
         }


### PR DESCRIPTION
When you have keys separate with dots  always show the first key that finds with the first segment
For example if in your language files you have: 
```php
'location' => 'location',
'location.all' => 'all locations',
```
In the js side you will has bad translations
```js
Lang.get('location') // returns location
Lang.get('location.all') // also returns location
```

Other comment about this issue:
https://github.com/rmariuzzo/Laravel-JS-Localization/issues/115#issuecomment-348512505