### PR TITLE
Prioritize dot notations if has a parent key

### DIFF
--- a/test/fixture/messages.json
+++ b/test/fixture/messages.json
@@ -109,6 +109,8 @@
         },
         "plural": "one apple|a million apples",
         "dot.in.key": "Dot In Key",
+        "with_parent": "Key That Is Subpart Of A Parent Key",
+        "with_parent.dot.in.key": "Dot In Key With a Parent Key",
         "dot.in.key2.nested": {
             "dot.in.key2.nested": "Dot In Key Nested Tricky"
         },

--- a/test/spec/lang_get_spec.js
+++ b/test/spec/lang_get_spec.js
@@ -69,6 +69,10 @@ describe('The lang.get() method', function () {
         expect(lang.get('messages.dot.in.key')).toBe('Dot In Key');
     });
 
+    it('should prioritize the dot in key', function() {
+        expect(lang.get('messages.with_parent.dot.in.key')).toBe('Dot In Key With a Parent Key');
+    });
+
     it('should return the expected message if the key is nested and has a dot', function() {
         expect(lang.get('messages.dotInKey.dot.in.key')).toBe('Dot In Key Nested Simple');
         expect(lang.get('messages.dot.in.key2.nested.dot.in.key2.nested')).toBe('Dot In Key Nested Tricky');


### PR DESCRIPTION
When we have a string with dot notation and another string that has part of the second string currently it prioritizes the second string.

ej:
```
{
'hello' => 'Hello',
'hello.world' => 'Hello World'
}
```

`Lang.get('app.hello.world')` ==> Hello

This PR should solve the problem
I made a new recursively function to get the value and add some tests

