### PR TITLE
Change of node version at the time of building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.10"
+    - "7"
 install:
     - npm install
 script: npm run build


### PR DESCRIPTION
Hey @rmariuzzo 

Reviewing this, I could see that the **build** was not happening in travis and it is because of the version of the Node that you have in the **.travs.yml**, the library **jasmine-node** was having ES6 syntax problems at the time it was executed .

![Lang.JS error](https://user-images.githubusercontent.com/1984746/62731094-6687aa00-b9ef-11e9-8e07-8ae5538ab7ca.png)

> You can check line 481

That said then I proceeded to change the version to a more stable one for compilation and everything works correctly.