### PR TITLE
Added feature Translation Strings as Keys

### DIFF
--- a/src/lang.js
+++ b/src/lang.js
@@ -272,7 +272,7 @@
      */
     Lang.prototype._getMessage = function(key, locale) {
         locale = locale || this.getLocale();
-        let originalLocale = locale;
+        var originalLocale = locale;
 
         // Handle the scenario where the tranlation string is used as the key.
         // (https://laravel.com/docs/6.x/localization#using-translation-strings-as-keys)

--- a/src/lang.js
+++ b/src/lang.js
@@ -272,6 +272,41 @@
      */
     Lang.prototype._getMessage = function(key, locale) {
         locale = locale || this.getLocale();
+        let originalLocale = locale;
+
+        // Handle the scenario where the tranlation string is used as the key.
+        // (https://laravel.com/docs/6.x/localization#using-translation-strings-as-keys)
+        // In this case the Key should be present at the root of the locale.
+        if (typeof(this.messages[locale]) === 'undefined') {
+              // The given locale does not have keys at the root, use the fallback instead.
+              locale = this.getFallback();
+        }
+
+        
+        // See if the key is defined.
+        if (typeof(this.messages[locale]) !== 'undefined') {
+            if (typeof(this.messages[locale][key]) !== 'undefined') {
+                return this.messages[locale][key];
+            }
+        }
+
+        //Try with the fallback as well. if we haven't looked there already.
+        if (locale === originalLocale) {
+            locale = this.getFallback();
+            if (typeof(this.messages[locale]) !== 'undefined') {
+                if (typeof(this.messages[locale][key]) !== 'undefined') {
+                    return this.messages[locale][key];
+                }
+            }
+        }
+
+        // If we reach here, that means the traslation key did not exist in the provided locale
+        // nor the fallback locale. At this point proceed as normal and expect the rest of the code
+        // to find a valid translation or return the key itself as the translation
+        // (which also takes care of 'Translation strings as key')
+
+        // Reset to the original locale.
+        locale = originalLocale;
         
         key = this._parseKey(key, locale);
 

--- a/test/fixture/messages.json
+++ b/test/fixture/messages.json
@@ -216,5 +216,9 @@
     },
     "en.unique": {
         "samePrefixKeys": "Your order contains :items items with :itemsPapayas papayas and :itemsMangoes mangoes"
+    },
+    "es": {
+        "Hello": "Hola",
+        "Payment received. Thanks!": "Pago recibido. Gracias!"
     }
 }

--- a/test/spec/lang_fallback_spec.js
+++ b/test/spec/lang_fallback_spec.js
@@ -58,4 +58,23 @@ describe('The lang\'s fallback locale feature', function() {
             lang.get('greetings.hello');
         }).not.toThrow();
     });
+
+    // JSON Translation string as keys
+    it('should return the fallback if tranlation is not availble.', function() {
+        var messages = {
+            'en': {
+                'Welcome': 'Welcome to the site.'
+            },
+            'es': {
+                'Hello': 'Hola',
+            }
+        };
+        lang = new Lang({
+            messages: messages
+        });
+        lang.setLocale('es');
+        lang.setFallback('en');
+        
+        expect(lang.get('Welcome', [], 'es')).toBe('Welcome to the site.');
+    })
 });

--- a/test/spec/lang_get_spec.js
+++ b/test/spec/lang_get_spec.js
@@ -89,4 +89,13 @@ describe('The lang.get() method', function () {
             itemsMangoes: 2
         })).toBe('Your order contains 5 items with 3 papayas and 2 mangoes');
     });
+
+    // JSON Translation string as key
+    it('should return the spanish translation when a key exists', function() {
+        expect(lang.get('Hello', [], 'es')).toBe('Hola');
+    });
+
+    it('should return the spanish translation when a key exists and key contains a period (.)', function() {
+        expect(lang.get('Payment received. Thanks!', [], 'es')).toBe('Pago recibido. Gracias!');
+    });
 });


### PR DESCRIPTION
This PR will add larave's Translation Strings and Keys feature to this library and resolves https://github.com/rmariuzzo/Lang.js/issues/69

With this update you can define translation keys at the root element of each locale, like this:

```
var messages = {
            'en': {
                'Welcome': 'Welcome to the site.'
            },
            'es': {
                'Hello': 'Hola',
            }
        };
        lang = new Lang({
            messages: messages
        });
        lang.setLocale('es');
        lang.setFallback('en');
```
This will produce the following outputs
`lang.get('Welcome')` ---> `Welcome to the site`
`lang.get('Non existing')` --> `Non existing`
`lang.get('Hello')` --> 'Hola`

